### PR TITLE
feat: add allowRead support and document sandbox precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ $ curl https://registry.npmjs.org
 - `~/.aws/credentials`, `~/.config/gcloud`
 - `~/.npmrc`, `~/.env`
 
+**Filesystem (allow-read)**:
+- Empty by default
+
 **Filesystem (allow-write)**:
 - Project directory
 - Git worktree (validated — unsafe paths like `/` are rejected)
@@ -147,6 +150,7 @@ If `XDG_CONFIG_HOME` is set, it is used instead of `~/.config`.
 {
   "filesystem": {
     "denyRead": ["~/.ssh", "~/.aws/credentials"],
+    "allowRead": ["~/.ssh/id_ed25519.pub"],
     "allowWrite": [".", "/tmp", "/var/data"],
     "denyWrite": [".env.production"]
   },
@@ -160,6 +164,39 @@ If `XDG_CONFIG_HOME` is set, it is used instead of `~/.config`.
       "my-internal-api.company.com"
     ],
     "deniedDomains": ["malicious.example.com"]
+  }
+}
+```
+
+### Path precedence
+
+Path precedence is inherited from `@anthropic-ai/sandbox-runtime`:
+
+- Read: `allowRead` takes precedence over `denyRead`
+- Write: `denyWrite` takes precedence over `allowWrite`
+
+### Example: allow git commit signing with SSH public key
+
+If your Git workflow needs to read a public key (for example `~/.ssh/id_ed25519.pub`) while keeping `~/.ssh` blocked by default, re-allow only that file:
+
+```json
+// ~/.config/opencode-sandbox/config.json
+{
+  "filesystem": {
+    "denyRead": [
+      "~/.ssh",
+      "~/.gnupg",
+      "~/.aws/credentials",
+      "~/.azure",
+      "~/.config/gcloud",
+      "~/.config/gh",
+      "~/.kube",
+      "~/.docker/config.json",
+      "~/.npmrc",
+      "~/.netrc",
+      "~/.env"
+    ],
+    "allowRead": ["~/.ssh/id_ed25519.pub"]
   }
 }
 ```
@@ -179,6 +216,12 @@ If `XDG_CONFIG_HOME` is set, it is used instead of `~/.config`.
 
 ```bash
 OPENCODE_SANDBOX_CONFIG='{"filesystem":{"denyRead":["~/.ssh"]},"network":{"allowedDomains":["github.com"]}}' opencode
+```
+
+Example allowing only the SSH public key to be read:
+
+```bash
+OPENCODE_SANDBOX_CONFIG='{"filesystem":{"denyRead":["~/.ssh","~/.gnupg","~/.aws/credentials","~/.azure","~/.config/gcloud","~/.config/gh","~/.kube","~/.docker/config.json","~/.npmrc","~/.netrc","~/.env"],"allowRead":["~/.ssh/id_ed25519.pub"]}}' opencode
 ```
 
 ### Disable

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,6 +7,7 @@ export interface SandboxPluginConfig {
   disabled?: boolean
   filesystem?: {
     denyRead?: string[]
+    allowRead?: string[]
     allowWrite?: string[]
     denyWrite?: string[]
   }
@@ -90,6 +91,7 @@ export function resolveConfig(
     filesystem: {
       denyRead:
         user?.filesystem?.denyRead ?? DEFAULT_DENY_READ_DIRS.map((p) => path.join(homeDir, p)),
+      allowRead: user?.filesystem?.allowRead ?? [],
       allowWrite: writePaths,
       denyWrite: user?.filesystem?.denyWrite ?? [],
     },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -24,6 +24,7 @@ describe("resolveConfig", () => {
     expect(config.filesystem?.denyRead).toContain(path.join(os.homedir(), ".npmrc"))
     expect(config.filesystem?.denyRead).toContain(path.join(os.homedir(), ".netrc"))
     expect(config.filesystem?.denyRead).toContain(path.join(os.homedir(), ".env"))
+    expect(config.filesystem?.allowRead).toEqual([])
     expect(config.filesystem?.allowWrite).toContain(PROJECT_DIR)
     expect(config.filesystem?.allowWrite).toContain(os.tmpdir())
     expect(config.filesystem?.denyWrite).toEqual([])
@@ -41,6 +42,7 @@ describe("resolveConfig", () => {
     const user: SandboxPluginConfig = {
       filesystem: {
         denyRead: ["/custom/secret"],
+        allowRead: ["/custom/secret.pub"],
         allowWrite: ["/custom/output"],
         denyWrite: ["/custom/no-write"],
       },
@@ -48,6 +50,7 @@ describe("resolveConfig", () => {
     const config = resolveConfig(PROJECT_DIR, WORKTREE, user)
 
     expect(config.filesystem?.denyRead).toEqual(["/custom/secret"])
+    expect(config.filesystem?.allowRead).toEqual(["/custom/secret.pub"])
     expect(config.filesystem?.allowWrite).toEqual(["/custom/output"])
     expect(config.filesystem?.denyWrite).toEqual(["/custom/no-write"])
   })
@@ -69,12 +72,14 @@ describe("resolveConfig", () => {
     const user: SandboxPluginConfig = {
       filesystem: {
         denyRead: ["/only-this"],
+        allowRead: ["/except-this"],
       },
     }
     const config = resolveConfig(PROJECT_DIR, WORKTREE, user)
 
     // overridden
     expect(config.filesystem?.denyRead).toEqual(["/only-this"])
+    expect(config.filesystem?.allowRead).toEqual(["/except-this"])
     // defaults kept
     expect(config.filesystem?.allowWrite).toContain(PROJECT_DIR)
     expect(config.network?.allowedDomains).toContain("github.com")
@@ -156,11 +161,12 @@ describe("loadConfig", () => {
   test("loads config from OPENCODE_SANDBOX_CONFIG env var", async () => {
     process.env.OPENCODE_SANDBOX_CONFIG = JSON.stringify({
       disabled: false,
-      filesystem: { denyRead: ["/secret"] },
+      filesystem: { denyRead: ["/secret"], allowRead: ["/secret.pub"] },
     })
     const config = await loadConfig(PROJECT_DIR)
     expect(config.disabled).toBe(false)
     expect(config.filesystem?.denyRead).toEqual(["/secret"])
+    expect(config.filesystem?.allowRead).toEqual(["/secret.pub"])
   })
 
   test("loads per-project config", async () => {


### PR DESCRIPTION
## Summary
- Add `filesystem.allowRead` passthrough in plugin config so users can re-allow specific read paths while keeping broad deny rules.
- Extend config tests to validate default `allowRead` behavior and user-provided passthrough values.
- Document read/write precedence and add examples for SSH public-key access used in signed git commit workflows, including env-var usage.

## Testing
- `bun test test/config.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly allowing specific filesystem read paths to override default restrictions.

* **Documentation**
  * Expanded configuration documentation with new examples and path precedence rules explaining how allow and deny permissions interact for filesystem read and write operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->