### PR TITLE
fix: clean up sandbox mount artifacts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,14 +5,14 @@
     "": {
       "name": "opencode-sandbox",
       "dependencies": {
-        "@anthropic-ai/sandbox-runtime": "^0.0.37",
+        "@anthropic-ai/sandbox-runtime": "^0.0.50",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.0.0",
         "@opencode-ai/plugin": "^1.2.1",
         "@opencode-ai/sdk": "^1.2.1",
         "@types/bun": "^1.3.9",
-        "typescript": "^5.8.0",
+        "typescript": "^6.0.2",
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.0.0",
@@ -20,7 +20,7 @@
     },
   },
   "packages": {
-    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.37", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "@types/lodash-es": "^4.17.12", "commander": "^12.1.0", "lodash-es": "^4.17.23", "shell-quote": "^1.8.3", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-KKzHoe4blXQpTEtbFLKP76PHsUerqlG5UNN+MQvXf0SVZDtawP9hHc9HiMgzvUXST2OMYl2Sk27k18d6684eoQ=="],
+    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.50", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "shell-quote": "^1.8.3", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-2j0K7jfk72YM+JitJ+O/ml1U+XOlSduR3Vet8YI49ot9ah6TWHyDzFLVBAEk5NCWMdNPULPHok/H6/L9meoxmg=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.3.15", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.3.15", "@biomejs/cli-darwin-x64": "2.3.15", "@biomejs/cli-linux-arm64": "2.3.15", "@biomejs/cli-linux-arm64-musl": "2.3.15", "@biomejs/cli-linux-x64": "2.3.15", "@biomejs/cli-linux-x64-musl": "2.3.15", "@biomejs/cli-win32-arm64": "2.3.15", "@biomejs/cli-win32-x64": "2.3.15" }, "bin": { "biome": "bin/biome" } }, "sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g=="],
 
@@ -48,21 +48,15 @@
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
-    "@types/lodash": ["@types/lodash@4.17.23", "", {}, "sha512-RDvF6wTulMPjrNdCoYRC8gNR880JNGT8uB+REUpC2Ns4pRqQJhGz90wh7rgdXDPpCczF3VGktDuFGVnz8zP7HA=="],
-
-    "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
-
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
-    "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
-
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,23 +1,23 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime"
 
 export interface SandboxPluginConfig {
-  disabled?: boolean;
+  disabled?: boolean
   filesystem?: {
-    denyRead?: string[];
-    allowRead?: string[];
-    allowWrite?: string[];
-    denyWrite?: string[];
-  };
+    denyRead?: string[]
+    allowRead?: string[]
+    allowWrite?: string[]
+    denyWrite?: string[]
+  }
   network?: {
-    allowedDomains?: string[];
-    deniedDomains?: string[];
-    allowUnixSockets?: string[];
-    allowAllUnixSockets?: boolean;
-    allowLocalBinding?: boolean;
-  };
+    allowedDomains?: string[]
+    deniedDomains?: string[]
+    allowUnixSockets?: string[]
+    allowAllUnixSockets?: boolean
+    allowLocalBinding?: boolean
+  }
 }
 
 const DEFAULT_DENY_READ_DIRS = [
@@ -32,7 +32,7 @@ const DEFAULT_DENY_READ_DIRS = [
   ".npmrc",
   ".netrc",
   ".env",
-];
+]
 
 const DEFAULT_ALLOWED_DOMAINS = [
   "registry.npmjs.org",
@@ -52,7 +52,7 @@ const DEFAULT_ALLOWED_DOMAINS = [
   "api.anthropic.com",
   "generativelanguage.googleapis.com",
   "*.googleapis.com",
-];
+]
 
 const UNSAFE_WRITE_PATHS = new Set([
   "/",
@@ -66,15 +66,15 @@ const UNSAFE_WRITE_PATHS = new Set([
   "/private",
   "/Volumes",
   "/Users",
-]);
+])
 
 function isSafeWritePath(p: string): boolean {
-  const normalized = path.resolve(p);
+  const normalized = path.resolve(p)
   if (UNSAFE_WRITE_PATHS.has(normalized)) {
-    console.warn(`[opencode-sandbox] Rejecting unsafe write path: ${normalized}`);
-    return false;
+    console.warn(`[opencode-sandbox] Rejecting unsafe write path: ${normalized}`)
+    return false
   }
-  return true;
+  return true
 }
 
 export function resolveConfig(
@@ -82,19 +82,19 @@ export function resolveConfig(
   worktree: string,
   user?: SandboxPluginConfig,
 ): SandboxRuntimeConfig {
-  const homeDir = os.homedir();
+  const homeDir = os.homedir()
 
-  const candidatePaths = [projectDir, worktree, os.tmpdir()].filter(Boolean);
-  const safePaths = candidatePaths.filter((p) => isSafeWritePath(p));
-  const seen = new Set<string>();
+  const candidatePaths = [projectDir, worktree, os.tmpdir()].filter(Boolean)
+  const safePaths = candidatePaths.filter((p) => isSafeWritePath(p))
+  const seen = new Set<string>()
   const writePaths =
     user?.filesystem?.allowWrite ??
     safePaths.filter((p) => {
-      const resolved = path.resolve(p);
-      if (seen.has(resolved)) return false;
-      seen.add(resolved);
-      return true;
-    });
+      const resolved = path.resolve(p)
+      if (seen.has(resolved)) return false
+      seen.add(resolved)
+      return true
+    })
 
   return {
     filesystem: {
@@ -111,43 +111,43 @@ export function resolveConfig(
       allowAllUnixSockets: user?.network?.allowAllUnixSockets,
       allowLocalBinding: user?.network?.allowLocalBinding ?? false,
     },
-  };
+  }
 }
 
 export function getConfigDir(): string {
-  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-  return path.join(xdgConfig, "opencode-sandbox");
+  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config")
+  return path.join(xdgConfig, "opencode-sandbox")
 }
 
 async function tryLoadJsonFile(filePath: string): Promise<SandboxPluginConfig | null> {
   try {
-    const content = await fs.readFile(filePath, "utf-8");
-    return JSON.parse(content) as SandboxPluginConfig;
+    const content = await fs.readFile(filePath, "utf-8")
+    return JSON.parse(content) as SandboxPluginConfig
   } catch {
-    return null;
+    return null
   }
 }
 
 export async function loadConfig(projectDir: string): Promise<SandboxPluginConfig> {
-  const envConfig = process.env.OPENCODE_SANDBOX_CONFIG;
+  const envConfig = process.env.OPENCODE_SANDBOX_CONFIG
   if (envConfig) {
     try {
-      return JSON.parse(envConfig) as SandboxPluginConfig;
+      return JSON.parse(envConfig) as SandboxPluginConfig
     } catch {
-      console.warn("[opencode-sandbox] Invalid JSON in OPENCODE_SANDBOX_CONFIG, using defaults");
+      console.warn("[opencode-sandbox] Invalid JSON in OPENCODE_SANDBOX_CONFIG, using defaults")
     }
   }
 
-  const configDir = getConfigDir();
+  const configDir = getConfigDir()
 
-  const projectName = path.basename(projectDir);
+  const projectName = path.basename(projectDir)
   const projectConfig = await tryLoadJsonFile(
     path.join(configDir, "projects", `${projectName}.json`),
-  );
-  if (projectConfig) return projectConfig;
+  )
+  if (projectConfig) return projectConfig
 
-  const globalConfig = await tryLoadJsonFile(path.join(configDir, "config.json"));
-  if (globalConfig) return globalConfig;
+  const globalConfig = await tryLoadJsonFile(path.join(configDir, "config.json"))
+  if (globalConfig) return globalConfig
 
-  return {};
+  return {}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
   if (!sandboxReady) return {}
 
   const originalCommands = new Map<string, string>()
+  const sandboxedCommands = new Set<string>()
 
   return {
     "tool.execute.before": async (input, output) => {
@@ -52,6 +53,7 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
 
       try {
         output.args.command = await SandboxManager.wrapWithSandbox(command)
+        sandboxedCommands.add(input.callID)
       } catch (err) {
         console.warn(
           "[opencode-sandbox] Failed to wrap command, running unsandboxed:",
@@ -63,11 +65,22 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
     "tool.execute.after": async (input, _output) => {
       if (input.tool !== "bash") return
 
+      if (sandboxedCommands.delete(input.callID)) {
+        try {
+          SandboxManager.cleanupAfterCommand()
+        } catch (err) {
+          console.warn(
+            "[opencode-sandbox] Failed to clean up sandbox artifacts:",
+            err instanceof Error ? err.message : err,
+          )
+        }
+      }
+
       // Restore original command so the UI shows it instead of the bwrap wrapper
       const originalCommand = originalCommands.get(input.callID)
+      originalCommands.delete(input.callID)
       if (originalCommand && input.args && typeof input.args.command === "string") {
         input.args.command = originalCommand
-        originalCommands.delete(input.callID)
       }
     },
   }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test"
 // Mock the SandboxManager before importing the plugin
 const mockInitialize = mock(() => Promise.resolve())
 const mockWrapWithSandbox = mock((cmd: string) => Promise.resolve(`srt-wrapped: ${cmd}`))
+const mockCleanupAfterCommand = mock(() => undefined)
 const mockReset = mock(() => Promise.resolve())
 
 mock.module("@anthropic-ai/sandbox-runtime", () => ({
   SandboxManager: {
     initialize: mockInitialize,
     wrapWithSandbox: mockWrapWithSandbox,
+    cleanupAfterCommand: mockCleanupAfterCommand,
     reset: mockReset,
   },
 }))
@@ -28,6 +30,7 @@ describe("SandboxPlugin", () => {
   beforeEach(() => {
     mockInitialize.mockClear()
     mockWrapWithSandbox.mockClear()
+    mockCleanupAfterCommand.mockClear()
     delete process.env.OPENCODE_DISABLE_SANDBOX
     delete process.env.OPENCODE_SANDBOX_CONFIG
   })
@@ -137,6 +140,54 @@ describe("SandboxPlugin", () => {
 
     // Command should remain unchanged (fail open)
     expect(output.args.command).toBe("echo hello")
+    expect(mockCleanupAfterCommand).not.toHaveBeenCalled()
+  })
+
+  test("cleans up sandbox mount points after wrapped bash command completes", async () => {
+    if (process.platform === "win32") return
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: "echo hello" } }
+
+    await hooks["tool.execute.before"]?.(input, output)
+
+    await hooks["tool.execute.after"]?.(
+      {
+        tool: "bash",
+        sessionID: "s1",
+        callID: "c1",
+        args: { command: output.args.command },
+      },
+      {},
+    )
+
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not clean up sandbox mount points when wrapping failed", async () => {
+    if (process.platform === "win32") return
+
+    mockWrapWithSandbox.mockImplementationOnce(() => {
+      throw new Error("bwrap not found")
+    })
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: "echo hello" } }
+
+    await hooks["tool.execute.before"]?.(input, output)
+    await hooks["tool.execute.after"]?.(
+      {
+        tool: "bash",
+        sessionID: "s1",
+        callID: "c1",
+        args: { command: output.args.command },
+      },
+      {},
+    )
+
+    expect(mockCleanupAfterCommand).not.toHaveBeenCalled()
   })
 
   test("restores correct command for concurrent bash calls", async () => {


### PR DESCRIPTION
## Summary
- Call `SandboxManager.cleanupAfterCommand()` after successfully wrapped bash commands finish so Linux bwrap mountpoint artifacts are removed.
- Track successfully wrapped call IDs so failed-open commands do not decrement sandbox cleanup state.
- Add regression coverage for cleanup behavior and refresh the stale lockfile/runtime entry.
- Format `src/config.ts` so `bun run check` passes in CI.

## Test Plan
- `bun run check`
- `bun run typecheck`
- `bun test`
- `bun run build`
- Smoke check: a sandboxed temp project created `.bashrc`, `.bash_profile`, `.mcp.json`, `.claude`, etc. before cleanup; `SandboxManager.cleanupAfterCommand()` removed them all (`after: []`). The local command itself exited with the environment-specific `apply-seccomp` userns permission error, but the artifact cleanup path was exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sandbox artifact cleanup to execute only for successfully wrapped commands, ensuring proper resource cleanup and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->