### PR TITLE
fix: avoid nested sandbox wrapping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,16 @@ import { loadConfig, resolveConfig } from "./config"
 
 export type { SandboxPluginConfig } from "./config"
 
+export function isSandboxWrappedCommand(command: string): boolean {
+  const trimmed = command.trim()
+  const linuxWrapper =
+    /^(?:[^\s'"]*\/)?bwrap\s/.test(trimmed) &&
+    /\s--setenv\s+SANDBOX_RUNTIME\s+1(?:\s|$)/.test(trimmed)
+  const macosWrapper =
+    /^env\s+SANDBOX_RUNTIME=1\s/.test(trimmed) && /\s\/usr\/bin\/sandbox-exec\s/.test(trimmed)
+  return linuxWrapper || macosWrapper
+}
+
 export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
   if (process.platform === "win32") {
     console.warn("[opencode-sandbox] Not supported on Windows — sandbox disabled")
@@ -47,6 +57,7 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
 
       const command = output.args?.command
       if (typeof command !== "string" || !command) return
+      if (isSandboxWrappedCommand(command)) return
 
       originalCommands.set(input.callID, command)
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -13,7 +13,7 @@ mock.module("@anthropic-ai/sandbox-runtime", () => ({
   },
 }))
 
-import { SandboxPlugin } from "../src/index"
+import { isSandboxWrappedCommand, SandboxPlugin } from "../src/index"
 
 const makeCtx = (dir = "/tmp/project", worktree = "/tmp/project") => ({
   client: {} as any,
@@ -59,6 +59,35 @@ describe("SandboxPlugin", () => {
 
     expect(mockWrapWithSandbox).toHaveBeenCalledWith("ls -la")
     expect(output.args.command).toBe("srt-wrapped: ls -la")
+  })
+
+  test("does not wrap commands already wrapped by sandbox-runtime", async () => {
+    if (process.platform === "win32") return
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const alreadyWrapped =
+      "bwrap --new-session --die-with-parent --setenv SANDBOX_RUNTIME 1 -- /usr/bin/bash -c 'echo hello'"
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: alreadyWrapped } }
+
+    await hooks["tool.execute.before"]?.(input, output)
+
+    expect(mockWrapWithSandbox).not.toHaveBeenCalled()
+    expect(output.args.command).toBe(alreadyWrapped)
+  })
+
+  test("detects sandbox-runtime wrappers without matching ordinary commands", () => {
+    expect(
+      isSandboxWrappedCommand(
+        "bwrap --new-session --die-with-parent --setenv SANDBOX_RUNTIME 1 -- /usr/bin/bash -c 'echo hello'",
+      ),
+    ).toBe(true)
+    expect(
+      isSandboxWrappedCommand(
+        "env SANDBOX_RUNTIME=1 TMPDIR=/tmp/claude /usr/bin/sandbox-exec -p '(version 1)' /bin/bash -c 'echo hello'",
+      ),
+    ).toBe(true)
+    expect(isSandboxWrappedCommand("echo SANDBOX_RUNTIME=1 bwrap")).toBe(false)
   })
 
   test("does not wrap non-bash tools", async () => {


### PR DESCRIPTION
## Summary
- Add a conservative detector for commands that already look wrapped by `@anthropic-ai/sandbox-runtime`.
- Skip `SandboxManager.wrapWithSandbox()` for those already wrapped commands so retry/re-entry paths do not produce nested `bwrap` / `sandbox-exec` commands.
- Add regression coverage for Linux and macOS wrapper shapes, plus a non-match case for ordinary commands that merely mention sandbox markers.

Fixes #41.

## Root cause
The plugin wrapped every `bash` command it saw in `tool.execute.before`. If OpenCode or a retry path fed a command that had already been transformed by sandbox-runtime back through the hook, the plugin wrapped the wrapper again, causing very long nested commands and quoting failures like the one shown in #41.

## Validation
- `bun test test/plugin.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run build`
- `bunx biome check src/index.ts test/plugin.test.ts`
- `git diff --check`

Note: a full `bun run check` on current `main` reports pre-existing formatting drift in `src/config.ts`, which this PR does not touch. The Biome check above covers the changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents commands from being wrapped twice in sandboxed execution, improving reliability for already pre-wrapped commands.
  * Keeps the original command unchanged when sandbox wrapping is already present, reducing unexpected execution issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->