### PR TITLE
fix: use first-interaction v3 input names

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue! We appreciate you taking the time to report this.
 
             A maintainer will review it soon. In the meantime, please make sure you've included all the relevant details (OS, plugin version, steps to reproduce).
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request! We're excited to review your contribution.
 
             Please make sure:


### PR DESCRIPTION
## Summary
- update the `actions/first-interaction@v3` inputs in the Welcome workflow to the snake_case names expected by the action
- keep the greeting messages and permissions unchanged

## Root cause
The current workflow passes `repo-token`, `issue-message`, and `pr-message`, but `actions/first-interaction@v3` defines `repo_token`, `issue_message`, and `pr_message`. The current configuration fails before posting the welcome comment with `Input required and not supplied: issue_message`.

## Validation
- Confirmed `actions/first-interaction@v3` action metadata defines `repo_token`, `issue_message`, and `pr_message`
- Reproduced from the failed `welcome` check log on #52: `Input required and not supplied: issue_message`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/welcome.yml"); puts "workflow yaml parsed"'
- `bun run typecheck`
- `bun test`
- `git diff --check`

Note: `bun run check` currently reports a pre-existing `src/config.ts` formatting baseline issue on `main`; this PR only changes the workflow YAML and does not touch source formatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated welcome workflow to use the current input naming format for first-time interaction messages.
  * Preserved the existing welcome content while ensuring issue and pull request messages continue to post correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->