### PR TITLE
fix: move macOS Seatbelt profile to a temp file to stop context bloat

### DIFF
--- a/src/deinline-profile.ts
+++ b/src/deinline-profile.ts
@@ -1,0 +1,59 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+export interface DeinlinedCommand {
+  /** The command to execute — compact when the profile was moved to a file. */
+  command: string
+  /** Path to the temp profile file, or null when nothing was rewritten. */
+  profilePath: string | null
+}
+
+const OPENER = 'sandbox-exec -p "'
+
+/**
+ * On macOS, `@anthropic-ai/sandbox-runtime` inlines the full Seatbelt profile
+ * into the command via `sandbox-exec -p "<profile>"`. That profile is tens of
+ * thousands of characters, and OpenCode echoes the executed command into the
+ * tool result — so the inline profile floods the model's context on every
+ * sandboxed bash call.
+ *
+ * This rewrites `sandbox-exec -p "<profile>"` to `sandbox-exec -f <tmpfile>`,
+ * writing the (unescaped) profile to a private temp file. The executed argv is
+ * unchanged — only its textual size shrinks — so sandbox behaviour is identical.
+ *
+ * On Linux (bubblewrap) the wrapped command contains no such marker, so this is
+ * a no-op and the original command is returned untouched.
+ */
+export async function deinlineMacosProfile(wrapped: string): Promise<DeinlinedCommand> {
+  const anchor = wrapped.indexOf(OPENER)
+  if (anchor === -1) return { command: wrapped, profilePath: null }
+
+  const start = anchor + OPENER.length
+
+  // Find the closing double-quote, honouring shell backslash escapes so an
+  // escaped `\"` inside the profile is not mistaken for the terminator.
+  let i = start
+  for (; i < wrapped.length; i++) {
+    if (wrapped[i] === "\\") {
+      i++
+      continue
+    }
+    if (wrapped[i] === '"') break
+  }
+  if (i >= wrapped.length) return { command: wrapped, profilePath: null }
+
+  const escaped = wrapped.slice(start, i)
+  // Reverse shell double-quote escaping so the file holds exactly the bytes the
+  // shell would have passed to `-p` (\" \$ \` \\ and line-continuations).
+  const profile = escaped.replace(/\\([$`"\\\n])/g, "$1")
+
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-sandbox-"))
+  const profilePath = path.join(dir, "profile.sb")
+  await fs.writeFile(profilePath, profile, { mode: 0o600 })
+
+  const command =
+    wrapped.slice(0, anchor) + `sandbox-exec -f "${profilePath}"` + wrapped.slice(i + 1)
+
+  return { command, profilePath }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs/promises"
+import path from "node:path"
 import { SandboxManager } from "@anthropic-ai/sandbox-runtime"
 import type { Plugin } from "@opencode-ai/plugin"
 import { loadConfig, resolveConfig } from "./config"
+import { deinlineMacosProfile } from "./deinline-profile"
 
 export type { SandboxPluginConfig } from "./config"
 
@@ -40,6 +43,7 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
   if (!sandboxReady) return {}
 
   const originalCommands = new Map<string, string>()
+  const profilePaths = new Map<string, string>()
 
   return {
     "tool.execute.before": async (input, output) => {
@@ -51,7 +55,14 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
       originalCommands.set(input.callID, command)
 
       try {
-        output.args.command = await SandboxManager.wrapWithSandbox(command)
+        const wrapped = await SandboxManager.wrapWithSandbox(command)
+        // macOS inlines the whole Seatbelt profile via `sandbox-exec -p`, which
+        // OpenCode then echoes into the tool result and floods the model's
+        // context. Move it to a temp file (`-f`) to keep the command compact;
+        // the executed argv — and thus the sandbox behaviour — is unchanged.
+        const { command: compact, profilePath } = await deinlineMacosProfile(wrapped)
+        output.args.command = compact
+        if (profilePath) profilePaths.set(input.callID, profilePath)
       } catch (err) {
         console.warn(
           "[opencode-sandbox] Failed to wrap command, running unsandboxed:",
@@ -63,11 +74,18 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
     "tool.execute.after": async (input, _output) => {
       if (input.tool !== "bash") return
 
-      // Restore original command so the UI shows it instead of the bwrap wrapper
+      // Restore original command so the UI shows it instead of the sandbox wrapper
       const originalCommand = originalCommands.get(input.callID)
       if (originalCommand && input.args && typeof input.args.command === "string") {
         input.args.command = originalCommand
-        originalCommands.delete(input.callID)
+      }
+      originalCommands.delete(input.callID)
+
+      // Clean up the temp profile file written for this command, if any.
+      const profilePath = profilePaths.get(input.callID)
+      if (profilePath) {
+        profilePaths.delete(input.callID)
+        await fs.rm(path.dirname(profilePath), { recursive: true, force: true }).catch(() => {})
       }
     },
   }

--- a/test/deinline-profile.test.ts
+++ b/test/deinline-profile.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { existsSync, readFileSync, rmSync } from "node:fs"
+import { deinlineMacosProfile } from "../src/deinline-profile"
+
+// Mimic how @anthropic-ai/sandbox-runtime shell-quotes the macOS wrapper:
+// `env … sandbox-exec -p "<profile>" /bin/bash -c "<cmd>"`, where the profile is
+// double-quoted and inner `"` `$` `\` are backslash-escaped.
+function fakeWrapped(profileRaw: string, innerCmd: string): string {
+  const escaped = profileRaw.replace(/([$`"\\])/g, "\\$1")
+  return `env SANDBOX_RUNTIME\\=1 sandbox-exec -p "${escaped}" /bin/bash -c "${innerCmd}"`
+}
+
+const cleanup: string[] = []
+afterEach(() => {
+  for (const p of cleanup.splice(0)) rmSync(p, { recursive: true, force: true })
+})
+
+describe("deinlineMacosProfile", () => {
+  test("moves the inline profile to a temp file and rewrites to -f", async () => {
+    // Realistically large: the real Seatbelt profile is tens of thousands of chars.
+    const profile =
+      `(version 1)\n(deny default (with message "TAG"))\n(allow process-exec)\n` +
+      Array.from({ length: 400 }, (_, n) => `(deny file-write* (subpath "/x/${n}"))`).join("\n")
+    const wrapped = fakeWrapped(profile, "curl example.com")
+
+    const { command, profilePath } = await deinlineMacosProfile(wrapped)
+    if (profilePath) cleanup.push(profilePath)
+
+    expect(profilePath).not.toBeNull()
+    expect(command).not.toContain("sandbox-exec -p")
+    expect(command).toContain(`sandbox-exec -f "${profilePath}"`)
+    // command is dramatically smaller than the inline form
+    expect(command.length).toBeLessThan(wrapped.length)
+    // env prefix and inner command are preserved verbatim
+    expect(command.startsWith("env SANDBOX_RUNTIME\\=1 sandbox-exec -f")).toBe(true)
+    expect(command.endsWith(`/bin/bash -c "curl example.com"`)).toBe(true)
+  })
+
+  test("writes the exact unescaped profile bytes to the file", async () => {
+    // Profile containing the characters shell-escaping cares about.
+    const profile = `(regex "^/x/\\.env$")\n(deny default (with message "T"))`
+    const wrapped = fakeWrapped(profile, "echo hi")
+
+    const { profilePath } = await deinlineMacosProfile(wrapped)
+    expect(profilePath).not.toBeNull()
+    if (!profilePath) return
+    cleanup.push(profilePath)
+
+    expect(existsSync(profilePath)).toBe(true)
+    expect(readFileSync(profilePath, "utf8")).toBe(profile)
+  })
+
+  test("is a no-op for non-macOS wrappers (no sandbox-exec -p marker)", async () => {
+    const wrapped = `bwrap --ro-bind / / /bin/bash -c "echo hi"`
+    const { command, profilePath } = await deinlineMacosProfile(wrapped)
+    expect(command).toBe(wrapped)
+    expect(profilePath).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

On macOS, every sandboxed bash command floods the model's context with the full Seatbelt profile.

`@anthropic-ai/sandbox-runtime` wraps commands as:

```
env … sandbox-exec -p "(version 1) …tens of thousands of chars… " /bin/bash -c "<cmd>"
```

The profile is inlined via `sandbox-exec -p`, and it is large because the runtime emits a `file-write-unlink` deny rule for every protected dotfile × every parent directory. A trivial `curl example.com` expands to a **~50–70k-character** command (~13–30k tokens depending on config).

OpenCode echoes the executed command into the tool result, so that inline profile lands in the model's context on **every** sandboxed bash call — and is especially visible on failing/blocked commands. The existing `tool.execute.after` restore of `input.args.command` can't help, because the bloat is already in the emitted result.

## Fix

In `tool.execute.before`, after `wrapWithSandbox`, rewrite the inline `sandbox-exec -p "<profile>"` into a file-based `sandbox-exec -f <tmpfile>`:

- The profile is written (unescaped) to a private temp file (`mode 0600`).
- Only the `-p "<profile>"` segment is replaced; the env prefix and inner `/bin/bash -c "<cmd>"` are preserved **byte-for-byte**, so the executed argv — and thus sandbox behaviour — is unchanged.
- The temp file is removed in `tool.execute.after`.
- No-op on Linux (bubblewrap output has no `sandbox-exec -p "` marker), and no-op if the marker isn't found (fails safe).

Result: the command handed to OpenCode shrinks from ~50k chars to ~1k chars (**~98%** smaller), eliminating the context bloat while keeping identical isolation.

## Validation

- New unit tests in `test/deinline-profile.test.ts` (extraction + `-f` rewrite, exact unescaped bytes written to disk, no-op for non-macOS wrappers).
- Manually verified against real `@anthropic-ai/sandbox-runtime` output on macOS that the `-f` command is **behaviourally identical** to the inline `-p` form across: allowed domain, blocked domain, allowed write, denied write.
- `bun test` (31 pass), `bun run typecheck`, `bun run check`, and `bun run build` all pass.

## Notes

The deeper cause is upstream (`sandbox-runtime` inlining via `-p`), but handling it in the plugin is safe, self-contained, and immediately fixes the OpenCode experience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved macOS sandbox command handling by storing lengthy security profiles in temporary files.
  * Keeps generated commands shorter while preserving their behavior and profile contents.
  * Automatically removes temporary profile files after command execution.
  * Non-macOS sandbox commands continue to work unchanged.

* **Tests**
  * Added coverage for profile extraction, command rewriting, content preservation, cleanup, and non-macOS behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->