### PR TITLE
test: cover macOS unsafe write paths

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,23 +1,23 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime";
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import type { SandboxRuntimeConfig } from "@anthropic-ai/sandbox-runtime"
 
 export interface SandboxPluginConfig {
-  disabled?: boolean;
+  disabled?: boolean
   filesystem?: {
-    denyRead?: string[];
-    allowRead?: string[];
-    allowWrite?: string[];
-    denyWrite?: string[];
-  };
+    denyRead?: string[]
+    allowRead?: string[]
+    allowWrite?: string[]
+    denyWrite?: string[]
+  }
   network?: {
-    allowedDomains?: string[];
-    deniedDomains?: string[];
-    allowUnixSockets?: string[];
-    allowAllUnixSockets?: boolean;
-    allowLocalBinding?: boolean;
-  };
+    allowedDomains?: string[]
+    deniedDomains?: string[]
+    allowUnixSockets?: string[]
+    allowAllUnixSockets?: boolean
+    allowLocalBinding?: boolean
+  }
 }
 
 const DEFAULT_DENY_READ_DIRS = [
@@ -32,7 +32,7 @@ const DEFAULT_DENY_READ_DIRS = [
   ".npmrc",
   ".netrc",
   ".env",
-];
+]
 
 const DEFAULT_ALLOWED_DOMAINS = [
   "registry.npmjs.org",
@@ -52,7 +52,7 @@ const DEFAULT_ALLOWED_DOMAINS = [
   "api.anthropic.com",
   "generativelanguage.googleapis.com",
   "*.googleapis.com",
-];
+]
 
 const UNSAFE_WRITE_PATHS = new Set([
   "/",
@@ -66,15 +66,15 @@ const UNSAFE_WRITE_PATHS = new Set([
   "/private",
   "/Volumes",
   "/Users",
-]);
+])
 
 function isSafeWritePath(p: string): boolean {
-  const normalized = path.resolve(p);
+  const normalized = path.resolve(p)
   if (UNSAFE_WRITE_PATHS.has(normalized)) {
-    console.warn(`[opencode-sandbox] Rejecting unsafe write path: ${normalized}`);
-    return false;
+    console.warn(`[opencode-sandbox] Rejecting unsafe write path: ${normalized}`)
+    return false
   }
-  return true;
+  return true
 }
 
 export function resolveConfig(
@@ -82,19 +82,19 @@ export function resolveConfig(
   worktree: string,
   user?: SandboxPluginConfig,
 ): SandboxRuntimeConfig {
-  const homeDir = os.homedir();
+  const homeDir = os.homedir()
 
-  const candidatePaths = [projectDir, worktree, os.tmpdir()].filter(Boolean);
-  const safePaths = candidatePaths.filter((p) => isSafeWritePath(p));
-  const seen = new Set<string>();
+  const candidatePaths = [projectDir, worktree, os.tmpdir()].filter(Boolean)
+  const safePaths = candidatePaths.filter((p) => isSafeWritePath(p))
+  const seen = new Set<string>()
   const writePaths =
     user?.filesystem?.allowWrite ??
     safePaths.filter((p) => {
-      const resolved = path.resolve(p);
-      if (seen.has(resolved)) return false;
-      seen.add(resolved);
-      return true;
-    });
+      const resolved = path.resolve(p)
+      if (seen.has(resolved)) return false
+      seen.add(resolved)
+      return true
+    })
 
   return {
     filesystem: {
@@ -111,43 +111,43 @@ export function resolveConfig(
       allowAllUnixSockets: user?.network?.allowAllUnixSockets,
       allowLocalBinding: user?.network?.allowLocalBinding ?? false,
     },
-  };
+  }
 }
 
 export function getConfigDir(): string {
-  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config");
-  return path.join(xdgConfig, "opencode-sandbox");
+  const xdgConfig = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config")
+  return path.join(xdgConfig, "opencode-sandbox")
 }
 
 async function tryLoadJsonFile(filePath: string): Promise<SandboxPluginConfig | null> {
   try {
-    const content = await fs.readFile(filePath, "utf-8");
-    return JSON.parse(content) as SandboxPluginConfig;
+    const content = await fs.readFile(filePath, "utf-8")
+    return JSON.parse(content) as SandboxPluginConfig
   } catch {
-    return null;
+    return null
   }
 }
 
 export async function loadConfig(projectDir: string): Promise<SandboxPluginConfig> {
-  const envConfig = process.env.OPENCODE_SANDBOX_CONFIG;
+  const envConfig = process.env.OPENCODE_SANDBOX_CONFIG
   if (envConfig) {
     try {
-      return JSON.parse(envConfig) as SandboxPluginConfig;
+      return JSON.parse(envConfig) as SandboxPluginConfig
     } catch {
-      console.warn("[opencode-sandbox] Invalid JSON in OPENCODE_SANDBOX_CONFIG, using defaults");
+      console.warn("[opencode-sandbox] Invalid JSON in OPENCODE_SANDBOX_CONFIG, using defaults")
     }
   }
 
-  const configDir = getConfigDir();
+  const configDir = getConfigDir()
 
-  const projectName = path.basename(projectDir);
+  const projectName = path.basename(projectDir)
   const projectConfig = await tryLoadJsonFile(
     path.join(configDir, "projects", `${projectName}.json`),
-  );
-  if (projectConfig) return projectConfig;
+  )
+  if (projectConfig) return projectConfig
 
-  const globalConfig = await tryLoadJsonFile(path.join(configDir, "config.json"));
-  if (globalConfig) return globalConfig;
+  const globalConfig = await tryLoadJsonFile(path.join(configDir, "config.json"))
+  if (globalConfig) return globalConfig
 
-  return {};
+  return {}
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -103,6 +103,13 @@ describe("resolveConfig", () => {
     expect(config.filesystem?.allowWrite).not.toContain("/usr")
   })
 
+  test("rejects macOS system paths from allowWrite", () => {
+    for (const unsafePath of ["/Library", "/System", "/private", "/Volumes", "/Users"]) {
+      const config = resolveConfig(unsafePath, "/project")
+      expect(config.filesystem?.allowWrite).not.toContain(unsafePath)
+    }
+  })
+
   test("deduplicates identical projectDir and worktree", () => {
     const config = resolveConfig("/project", "/project")
     const writeList = config.filesystem?.allowWrite ?? []


### PR DESCRIPTION
## Summary

Adds regression coverage for the macOS system paths already protected by the sandbox and normalizes a pre-existing formatting violation that blocked CI.

## Testing

- bun run check
- bun run typecheck
- bun test --coverage
- bun run build

Closes #33.