### PR TITLE
fix: defer sandbox initialization until command execution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,22 +27,23 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
 
   const runtimeConfig = resolveConfig(directory, worktree, userConfig)
 
-  let sandboxReady = false
-  try {
-    await SandboxManager.initialize(runtimeConfig)
-    sandboxReady = true
-    console.log(
-      `[opencode-sandbox] Initialized — writes allowed in: ${runtimeConfig.filesystem?.allowWrite?.join(", ")}`,
-    )
-  } catch (err) {
-    console.error(
-      "[opencode-sandbox] Failed to initialize:",
-      err instanceof Error ? err.message : err,
-    )
-    console.warn("[opencode-sandbox] Commands will run without sandbox")
-  }
-
-  if (!sandboxReady) return {}
+  let initialization: Promise<boolean> | undefined
+  const ensureSandboxReady = () =>
+    (initialization ??= SandboxManager.initialize(runtimeConfig)
+      .then(() => {
+        console.log(
+          `[opencode-sandbox] Initialized — writes allowed in: ${runtimeConfig.filesystem?.allowWrite?.join(", ")}`,
+        )
+        return true
+      })
+      .catch((err) => {
+        console.error(
+          "[opencode-sandbox] Failed to initialize:",
+          err instanceof Error ? err.message : err,
+        )
+        console.warn("[opencode-sandbox] Commands will run without sandbox")
+        return false
+      }))
 
   const originalCommands = new Map<string, string>()
 
@@ -53,6 +54,7 @@ export const SandboxPlugin: Plugin = async ({ directory, worktree }) => {
       const command = output.args?.command
       if (typeof command !== "string" || !command) return
       if (isSandboxWrappedCommand(command)) return
+      if (!(await ensureSandboxReady())) return
 
       originalCommands.set(input.callID, command)
 

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -36,13 +36,18 @@ describe("SandboxPlugin", () => {
     expect(server).toBe(SandboxPlugin)
   })
 
-  test("initializes sandbox on plugin load", async () => {
+  test("initializes sandbox only when the first bash command runs", async () => {
     if (process.platform === "win32") return
 
     const hooks = await SandboxPlugin(makeCtx())
-    expect(mockInitialize).toHaveBeenCalledTimes(1)
+    expect(mockInitialize).not.toHaveBeenCalled()
     expect(hooks["tool.execute.before"]).toBeDefined()
     expect(hooks["tool.execute.after"]).toBeDefined()
+
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: "echo hello" } }
+    await hooks["tool.execute.before"]?.(input, output)
+    expect(mockInitialize).toHaveBeenCalledTimes(1)
   })
 
   test("returns empty hooks when OPENCODE_DISABLE_SANDBOX=1", async () => {
@@ -148,7 +153,11 @@ describe("SandboxPlugin", () => {
       },
     })
 
-    await SandboxPlugin(makeCtx())
+    const hooks = await SandboxPlugin(makeCtx())
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      { args: { command: "echo hello" } },
+    )
 
     const callArg = mockInitialize.mock.calls[0]?.[0] as any
     expect(callArg.filesystem.denyRead).toEqual(["/custom/secret"])


### PR DESCRIPTION
Defers sandbox runtime startup until the first bash tool invocation, preventing it from affecting OpenCode startup requests. Validation: bun run check, bun run typecheck, bun test --coverage, bun run build. Closes #50.