### PR TITLE
feat: attribute sandbox violations by command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,13 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
       originalCommands.set(input.callID, command)
 
       try {
-        output.args.command = await SandboxManager.wrapWithSandbox(command)
+        output.args.command = await SandboxManager.wrapWithSandbox(
+          command,
+          undefined,
+          undefined,
+          undefined,
+          { commandId: input.callID, commandText: command },
+        )
       } catch (err) {
         void log(
           "warn",

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -66,7 +66,10 @@ describe("SandboxPlugin", () => {
 
     await hooks["tool.execute.before"]?.(input, output)
 
-    expect(mockWrapWithSandbox).toHaveBeenCalledWith("ls -la")
+    expect(mockWrapWithSandbox).toHaveBeenCalledWith("ls -la", undefined, undefined, undefined, {
+      commandId: "c1",
+      commandText: "ls -la",
+    })
     expect(output.args.command).toBe("srt-wrapped: ls -la")
   })
 


### PR DESCRIPTION
Passes OpenCode call IDs to the sandbox runtime as command attribution keys, preventing violations from similarly named commands being mixed together. Validation: bun run check, bun run typecheck, bun test --coverage, bun run build.