### PR TITLE
fix: clean up sandbox mount points after wrapped commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,8 +67,6 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
       if (isSandboxWrappedCommand(command)) return
       if (!(await ensureSandboxReady())) return
 
-      originalCommands.set(input.callID, command)
-
       try {
         output.args.command = await SandboxManager.wrapWithSandbox(
           command,
@@ -77,6 +75,7 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
           undefined,
           { commandId: input.callID, commandText: command },
         )
+        originalCommands.set(input.callID, command)
       } catch (err) {
         void log(
           "warn",
@@ -90,9 +89,20 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
 
       // Restore original command so the UI shows it instead of the bwrap wrapper
       const originalCommand = originalCommands.get(input.callID)
-      if (originalCommand && input.args && typeof input.args.command === "string") {
+      if (originalCommand === undefined) return
+
+      if (input.args && typeof input.args.command === "string") {
         input.args.command = originalCommand
-        originalCommands.delete(input.callID)
+      }
+      originalCommands.delete(input.callID)
+
+      try {
+        SandboxManager.cleanupAfterCommand()
+      } catch (err) {
+        void log(
+          "warn",
+          `Failed to clean up sandbox mount points: ${err instanceof Error ? err.message : String(err)}`,
+        )
       }
     },
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,24 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         return false
       }))
 
-  const originalCommands = new Map<string, string>()
+  const inFlight = new Map<string, { command: string; sessionID: string }>()
+
+  // Must run exactly once per successful wrapWithSandbox() call: the runtime
+  // refcounts mount points, and a missing cleanup leaves the count stuck above zero,
+  // deferring cleanup for every later command too. Deleting from the map first keeps
+  // this idempotent when both the after hook and the event hook see the same callID.
+  const finishCommand = (callID: string) => {
+    if (!inFlight.delete(callID)) return
+
+    try {
+      SandboxManager.cleanupAfterCommand()
+    } catch (err) {
+      void log(
+        "warn",
+        `Failed to clean up sandbox mount points: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }
 
   return {
     "tool.execute.before": async (input, output) => {
@@ -75,7 +92,7 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
           undefined,
           { commandId: input.callID, commandText: command },
         )
-        originalCommands.set(input.callID, command)
+        inFlight.set(input.callID, { command, sessionID: input.sessionID })
       } catch (err) {
         void log(
           "warn",
@@ -87,22 +104,42 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
     "tool.execute.after": async (input, _output) => {
       if (input.tool !== "bash") return
 
-      // Restore original command so the UI shows it instead of the bwrap wrapper
-      const originalCommand = originalCommands.get(input.callID)
-      if (originalCommand === undefined) return
+      // Restore the original command on the args object. NOTE: this does not
+      // change what the UI displays — part.state.input is snapshotted at the
+      // tool-call event (processor.ts:345) and only copied forward after that.
+      // It only matters if/when the bash tool streams ctx.metadata, which
+      // re-publishes `input: args` live (tools.ts:76).
+      const pending = inFlight.get(input.callID)
+      if (pending === undefined) return
 
       if (input.args && typeof input.args.command === "string") {
-        input.args.command = originalCommand
+        input.args.command = pending.command
       }
-      originalCommands.delete(input.callID)
 
-      try {
-        SandboxManager.cleanupAfterCommand()
-      } catch (err) {
-        void log(
-          "warn",
-          `Failed to clean up sandbox mount points: ${err instanceof Error ? err.message : String(err)}`,
-        )
+      finishCommand(input.callID)
+    },
+
+    // tool.execute.after never fires for an interrupted tool call — OpenCode aborts
+    // the effect before reaching the hook — so fall back to the event bus, which does
+    // report the abort. Without this, mount points from an interrupted command leak.
+    event: async ({ event }) => {
+      if (event.type === "message.part.updated") {
+        const { part } = event.properties
+        // On interrupt OpenCode marks the in-flight tool part as
+        // status "error" / metadata.interrupted; normal completion lands here too.
+        if (part.type !== "tool") return
+        if (part.state.status !== "error" && part.state.status !== "completed") return
+        finishCommand(part.callID)
+        return
+      }
+
+      // Backstop for anything the part update missed: once a session is idle none of
+      // its commands can still be running.
+      if (event.type === "session.idle") {
+        const { sessionID } = event.properties
+        for (const [callID, pending] of [...inFlight]) {
+          if (pending.sessionID === sessionID) finishCommand(callID)
+        }
       }
     },
   }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, mock, test } from "bun:test"
 // Mock the SandboxManager before importing the plugin
 const mockInitialize = mock(() => Promise.resolve())
 const mockWrapWithSandbox = mock((cmd: string) => Promise.resolve(`srt-wrapped: ${cmd}`))
+const mockCleanupAfterCommand = mock(() => undefined)
 const mockReset = mock(() => Promise.resolve())
 
 mock.module("@anthropic-ai/sandbox-runtime", () => ({
   SandboxManager: {
     initialize: mockInitialize,
     wrapWithSandbox: mockWrapWithSandbox,
+    cleanupAfterCommand: mockCleanupAfterCommand,
     reset: mockReset,
   },
 }))
@@ -28,6 +30,7 @@ describe("SandboxPlugin", () => {
   beforeEach(() => {
     mockInitialize.mockClear()
     mockWrapWithSandbox.mockClear()
+    mockCleanupAfterCommand.mockClear()
     delete process.env.OPENCODE_DISABLE_SANDBOX
     delete process.env.OPENCODE_SANDBOX_CONFIG
   })
@@ -218,5 +221,41 @@ describe("SandboxPlugin", () => {
 
     expect(afterInput1.args.command).toBe("echo first")
     expect(afterInput2.args.command).toBe("echo second")
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(2)
+  })
+
+  test("cleans up Linux mount points after a wrapped bash command", async () => {
+    if (process.platform === "win32") return
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const beforeInput = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const beforeOutput = { args: { command: "echo hello" } }
+    await hooks["tool.execute.before"]?.(beforeInput, beforeOutput)
+
+    await hooks["tool.execute.after"]?.(
+      {
+        ...beforeInput,
+        args: { command: beforeOutput.args.command },
+      },
+      {},
+    )
+
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not clean up a command that failed to wrap", async () => {
+    if (process.platform === "win32") return
+
+    mockWrapWithSandbox.mockImplementationOnce(() => {
+      throw new Error("bwrap not found")
+    })
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: "echo hello" } }
+    await hooks["tool.execute.before"]?.(input, output)
+    await hooks["tool.execute.after"]?.({ ...input, args: output.args }, {})
+
+    expect(mockCleanupAfterCommand).not.toHaveBeenCalled()
   })
 })

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -258,4 +258,72 @@ describe("SandboxPlugin", () => {
 
     expect(mockCleanupAfterCommand).not.toHaveBeenCalled()
   })
+
+  test("cleans up when an interrupted bash call never reaches tool.execute.after", async () => {
+    if (process.platform === "win32") return
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    await hooks["tool.execute.before"]?.(input, { args: { command: "sleep 100" } })
+
+    // On interrupt OpenCode marks the in-flight tool part errored instead of
+    // running tool.execute.after
+    await hooks.event?.({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            type: "tool",
+            callID: "c1",
+            state: { status: "error", error: "Tool execution aborted" },
+          },
+        },
+      } as any,
+    })
+
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+  })
+
+  test("cleans up interrupted calls at most once", async () => {
+    if (process.platform === "win32") return
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: "sleep 100" } }
+    await hooks["tool.execute.before"]?.(input, output)
+
+    const errored = {
+      event: {
+        type: "message.part.updated",
+        properties: {
+          part: { type: "tool", callID: "c1", state: { status: "error", error: "aborted" } },
+        },
+      } as any,
+    }
+    await hooks.event?.(errored)
+    await hooks.event?.(errored)
+    await hooks["tool.execute.after"]?.({ ...input, args: output.args }, {})
+
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+  })
+
+  test("session.idle cleans up only its own session's leftover commands", async () => {
+    if (process.platform === "win32") return
+
+    const hooks = await SandboxPlugin(makeCtx())
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      { args: { command: "sleep 100" } },
+    )
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s2", callID: "c2" },
+      { args: { command: "sleep 100" } },
+    )
+
+    await hooks.event?.({
+      event: { type: "session.idle", properties: { sessionID: "s1" } } as any,
+    })
+
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
## Summary

Fixes the continued existence of the temporary mount points used by the sandbox environment *after* command(s) have finished. These include things like `.bashrc`, `.bash_profile`, `.gitmodules`, `.gitconfig`, etc.

Luckily, `SandboxManager` already provided a `cleanupAfterCommand` method that we can use in the post hook.

## Changes

- Move `originalCommands.set()` to after the sandbox wrap so the original command is only stored when wrapping succeeds. Add `cleanupAfterCommand` call in the after hook to remove sandbox mount points, and add a try/catch to gracefully handle cleanup failures.

## Testing

- [x] All existing tests pass (`bun test`)
- [x] New tests added (if applicable)
- [x] Tested manually on Linux / macOS (specify which) (tested on `linux`)

## Related Issues

None. I never filed one.
