### PR TITLE
fix: hide sandbox wrapper from tool history

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,70 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         return false
       }))
 
-  const inFlight = new Map<string, { command: string; sessionID: string }>()
+  type MutableToolPart = {
+    id?: string
+    sessionID?: string
+    messageID?: string
+    callID: string
+    tool?: string
+    state?: { input?: { command?: unknown }; status?: string }
+  }
+
+  type ClientWithPartUpdate = typeof client & {
+    part?: {
+      update?: (input: {
+        sessionID: string
+        messageID: string
+        partID: string
+        part: MutableToolPart
+      }) => Promise<unknown>
+    }
+  }
+
+  const inFlight = new Map<
+    string,
+    { command: string; sessionID: string; scrubbedPartIDs: Set<string> }
+  >()
+
+  const scrubToolPartInput = async (part: MutableToolPart) => {
+    const pending = inFlight.get(part.callID)
+    if (pending === undefined) return
+    if (part.tool !== undefined && part.tool !== "bash") return
+
+    const input = part.state?.input
+    if (input === undefined) return
+    const command = input.command
+    if (typeof command !== "string" || command === pending.command) return
+
+    input.command = pending.command
+
+    if (
+      typeof part.id !== "string" ||
+      typeof part.sessionID !== "string" ||
+      typeof part.messageID !== "string" ||
+      pending.scrubbedPartIDs.has(part.id)
+    ) {
+      return
+    }
+    pending.scrubbedPartIDs.add(part.id)
+
+    const partClient = (client as ClientWithPartUpdate).part
+    if (typeof partClient?.update !== "function") return
+
+    try {
+      await partClient.update({
+        sessionID: part.sessionID,
+        messageID: part.messageID,
+        partID: part.id,
+        part,
+      })
+    } catch (err) {
+      void log(
+        "warn",
+        `Failed to restore original command in tool history: ${err instanceof Error ? err.message : String(err)}`,
+      )
+    }
+  }
 
   // Must run exactly once per successful wrapWithSandbox() call: the runtime
   // refcounts mount points, and a missing cleanup leaves the count stuck above zero,
@@ -92,7 +155,11 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
           undefined,
           { commandId: input.callID, commandText: command },
         )
-        inFlight.set(input.callID, { command, sessionID: input.sessionID })
+        inFlight.set(input.callID, {
+          command,
+          sessionID: input.sessionID,
+          scrubbedPartIDs: new Set(),
+        })
       } catch (err) {
         void log(
           "warn",
@@ -128,6 +195,7 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         // On interrupt OpenCode marks the in-flight tool part as
         // status "error" / metadata.interrupted; normal completion lands here too.
         if (part.type !== "tool") return
+        await scrubToolPartInput(part)
         if (part.state.status !== "error" && part.state.status !== "completed") return
         finishCommand(part.callID)
         return

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -17,8 +17,12 @@ mock.module("@anthropic-ai/sandbox-runtime", () => ({
 
 import { isSandboxWrappedCommand, SandboxPlugin, server } from "../src/index"
 
-const makeCtx = (dir = "/tmp/project", worktree = "/tmp/project") => ({
-  client: { app: { log: mock(() => Promise.resolve()) } } as any,
+const makeCtx = (
+  dir = "/tmp/project",
+  worktree = "/tmp/project",
+  client = { app: { log: mock(() => Promise.resolve()) } },
+) => ({
+  client: client as any,
   project: {} as any,
   directory: dir,
   worktree: worktree,
@@ -325,5 +329,81 @@ describe("SandboxPlugin", () => {
     })
 
     expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+  })
+
+  test("restores original command in persisted tool part history", async () => {
+    if (process.platform === "win32") return
+
+    const update = mock(() => Promise.resolve())
+    const hooks = await SandboxPlugin(
+      makeCtx("/tmp/project", "/tmp/project", {
+        app: { log: mock(() => Promise.resolve()) },
+        part: { update },
+      }),
+    )
+
+    const beforeOutput = { args: { command: "git status" } }
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      beforeOutput,
+    )
+
+    const part = {
+      id: "p1",
+      sessionID: "s1",
+      messageID: "m1",
+      type: "tool",
+      tool: "bash",
+      callID: "c1",
+      state: { status: "running", input: { command: beforeOutput.args.command } },
+    }
+
+    await hooks.event?.({
+      event: { type: "message.part.updated", properties: { part } } as any,
+    })
+
+    expect(part.state.input.command).toBe("git status")
+    expect(update).toHaveBeenCalledWith({
+      sessionID: "s1",
+      messageID: "m1",
+      partID: "p1",
+      part,
+    })
+    expect(mockCleanupAfterCommand).not.toHaveBeenCalled()
+  })
+
+  test("restores persisted tool part only once per part", async () => {
+    if (process.platform === "win32") return
+
+    const update = mock(() => Promise.resolve())
+    const hooks = await SandboxPlugin(
+      makeCtx("/tmp/project", "/tmp/project", {
+        app: { log: mock(() => Promise.resolve()) },
+        part: { update },
+      }),
+    )
+
+    const beforeOutput = { args: { command: "echo hello" } }
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      beforeOutput,
+    )
+
+    const part = {
+      id: "p1",
+      sessionID: "s1",
+      messageID: "m1",
+      type: "tool",
+      tool: "bash",
+      callID: "c1",
+      state: { status: "running", input: { command: beforeOutput.args.command } },
+    }
+
+    await hooks.event?.({ event: { type: "message.part.updated", properties: { part } } as any })
+    part.state.input.command = beforeOutput.args.command
+    await hooks.event?.({ event: { type: "message.part.updated", properties: { part } } as any })
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(part.state.input.command).toBe("echo hello")
   })
 })


### PR DESCRIPTION
## Summary

Fixes #79 by restoring the original bash command in persisted OpenCode tool parts after the sandbox wrapper has been inserted for execution.

## Changes

- Track wrapped commands with a per-call scrubbed part set.
- On `message.part.updated`, replace `part.state.input.command` with the original command before it remains visible in chat/history.
- Persist the restored part through `client.part.update` when that API is available.
- Keep sandbox execution unchanged and retain the existing cleanup behavior for completed/interrupted commands.

## Testing

- [x] `bun test`
- [x] `bun run typecheck`
- [x] `bun run check`