### PR TITLE
fix: preserve command state through final part update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { loadConfig, resolveConfig } from "./config"
 
 export type { SandboxPluginConfig } from "./config"
 
+const PERSISTENCE_WARNING = "Failed to restore original command in tool history"
+
 function isSandboxWrappedCommand(command: string): boolean {
   const trimmed = command.trim()
   const linuxWrapper =
@@ -14,7 +16,7 @@ function isSandboxWrappedCommand(command: string): boolean {
   return linuxWrapper || macosWrapper
 }
 
-export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => {
+export const SandboxPlugin: Plugin = async ({ client, directory, worktree, serverUrl }) => {
   const log = (level: "debug" | "warn" | "error", message: string) =>
     client.app.log({ body: { service: "opencode-sandbox", level, message } }).catch(() => undefined)
 
@@ -65,7 +67,7 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
     state?: { input?: { command?: unknown }; status?: string }
   }
 
-  type ClientWithPartUpdate = typeof client & {
+  type ClientWithPersistence = {
     part?: {
       update?: (input: {
         sessionID: string
@@ -74,7 +76,19 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         part: MutableToolPart
       }) => Promise<unknown>
     }
+    _client?: {
+      patch?: (input: {
+        url: string
+        path: { sessionID: string; messageID: string; partID: string }
+        query: { directory: string }
+        body: MutableToolPart
+        headers: { "Content-Type": string }
+      }) => Promise<unknown>
+    }
   }
+
+  const hasDefinedError = (result: unknown): result is { error: unknown } =>
+    typeof result === "object" && result !== null && "error" in result && result.error !== undefined
 
   const inFlight = new Map<string, { command: string; sessionID: string; cleaned: boolean }>()
 
@@ -98,21 +112,64 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
       return
     }
 
-    const partClient = (client as ClientWithPartUpdate).part
-    if (typeof partClient?.update !== "function") return
+    const persistenceClient = client as unknown as ClientWithPersistence
+    const partClient = persistenceClient.part
+    const internalClient = persistenceClient._client
 
     try {
-      await partClient.update({
-        sessionID: part.sessionID,
-        messageID: part.messageID,
-        partID: part.id,
-        part,
-      })
-    } catch (err) {
-      void log(
-        "warn",
-        `Failed to restore original command in tool history: ${err instanceof Error ? err.message : String(err)}`,
-      )
+      if (typeof partClient?.update === "function") {
+        const result = await partClient.update({
+          sessionID: part.sessionID,
+          messageID: part.messageID,
+          partID: part.id,
+          part,
+        })
+        if (hasDefinedError(result)) {
+          throw new Error("OpenCode public client failed to update tool history")
+        }
+      } else if (typeof internalClient?.patch === "function") {
+        let result: unknown
+        try {
+          result = await internalClient.patch({
+            url: "/session/{sessionID}/message/{messageID}/part/{partID}",
+            path: {
+              sessionID: part.sessionID,
+              messageID: part.messageID,
+              partID: part.id,
+            },
+            query: { directory },
+            body: part,
+            headers: { "Content-Type": "application/json" },
+          })
+        } catch {
+          throw new Error("OpenCode client transport failed to update tool history")
+        }
+        if (hasDefinedError(result)) {
+          throw new Error("OpenCode client transport failed to update tool history")
+        }
+      } else {
+        const url = new URL(
+          `/session/${encodeURIComponent(part.sessionID)}/message/${encodeURIComponent(part.messageID)}/part/${encodeURIComponent(part.id)}`,
+          serverUrl,
+        )
+        url.searchParams.set("directory", directory)
+        const headers: Record<string, string> = { "content-type": "application/json" }
+        const password = process.env.OPENCODE_SERVER_PASSWORD
+        if (password) {
+          const username = process.env.OPENCODE_SERVER_USERNAME ?? "opencode"
+          headers.authorization = `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`
+        }
+        const response = await fetch(url, {
+          method: "PATCH",
+          headers,
+          body: JSON.stringify(part),
+        })
+        if (!response.ok) {
+          throw new Error(`OpenCode server returned HTTP ${response.status}`)
+        }
+      }
+    } catch {
+      void log("warn", PERSISTENCE_WARNING)
     }
   }
 
@@ -199,9 +256,13 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         // On interrupt OpenCode marks the in-flight tool part as
         // status "error" / metadata.interrupted; normal completion lands here too.
         if (part.type !== "tool") return
-        await scrubToolPartInput(part)
-        if (part.state.status !== "error" && part.state.status !== "completed") return
-        finishCommand(part.callID)
+        const persistence = scrubToolPartInput(part)
+        if (part.state.status === "error" || part.state.status === "completed") {
+          finishCommand(part.callID)
+          await persistence
+          return
+        }
+        await persistence
         return
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,10 +76,7 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
     }
   }
 
-  const inFlight = new Map<
-    string,
-    { command: string; sessionID: string; scrubbedPartIDs: Set<string>; cleaned: boolean }
-  >()
+  const inFlight = new Map<string, { command: string; sessionID: string; cleaned: boolean }>()
 
   const scrubToolPartInput = async (part: MutableToolPart) => {
     const pending = inFlight.get(part.callID)
@@ -96,12 +93,10 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
     if (
       typeof part.id !== "string" ||
       typeof part.sessionID !== "string" ||
-      typeof part.messageID !== "string" ||
-      pending.scrubbedPartIDs.has(part.id)
+      typeof part.messageID !== "string"
     ) {
       return
     }
-    pending.scrubbedPartIDs.add(part.id)
 
     const partClient = (client as ClientWithPartUpdate).part
     if (typeof partClient?.update !== "function") return
@@ -165,7 +160,6 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         inFlight.set(input.callID, {
           command,
           sessionID: input.sessionID,
-          scrubbedPartIDs: new Set(),
           cleaned: false,
         })
       } catch (err) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { loadConfig, resolveConfig } from "./config"
 
 export type { SandboxPluginConfig } from "./config"
 
-export function isSandboxWrappedCommand(command: string): boolean {
+function isSandboxWrappedCommand(command: string): boolean {
   const trimmed = command.trim()
   const linuxWrapper =
     /^(?:[^\s'"]*\/)?bwrap\s/.test(trimmed) &&
@@ -78,7 +78,7 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
 
   const inFlight = new Map<
     string,
-    { command: string; sessionID: string; scrubbedPartIDs: Set<string> }
+    { command: string; sessionID: string; scrubbedPartIDs: Set<string>; cleaned: boolean }
   >()
 
   const scrubToolPartInput = async (part: MutableToolPart) => {
@@ -123,10 +123,10 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
 
   // Must run exactly once per successful wrapWithSandbox() call: the runtime
   // refcounts mount points, and a missing cleanup leaves the count stuck above zero,
-  // deferring cleanup for every later command too. Deleting from the map first keeps
-  // this idempotent when both the after hook and the event hook see the same callID.
-  const finishCommand = (callID: string) => {
-    if (!inFlight.delete(callID)) return
+  // deferring cleanup for every later command too.
+  const cleanupCommand = (pending: { cleaned: boolean }) => {
+    if (pending.cleaned) return
+    pending.cleaned = true
 
     try {
       SandboxManager.cleanupAfterCommand()
@@ -136,6 +136,13 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         `Failed to clean up sandbox mount points: ${err instanceof Error ? err.message : String(err)}`,
       )
     }
+  }
+
+  const finishCommand = (callID: string) => {
+    const pending = inFlight.get(callID)
+    if (pending === undefined) return
+    inFlight.delete(callID)
+    cleanupCommand(pending)
   }
 
   return {
@@ -159,6 +166,7 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
           command,
           sessionID: input.sessionID,
           scrubbedPartIDs: new Set(),
+          cleaned: false,
         })
       } catch (err) {
         void log(
@@ -183,7 +191,9 @@ export const SandboxPlugin: Plugin = async ({ client, directory, worktree }) => 
         input.args.command = pending.command
       }
 
-      finishCommand(input.callID)
+      // The final persisted part update arrives after this hook. Clean up now, but
+      // retain the original command until that event has had a chance to scrub it.
+      cleanupCommand(pending)
     },
 
     // tool.execute.after never fires for an interrupted tool call — OpenCode aborts

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test"
+import { createOpencodeClient } from "@opencode-ai/sdk"
 
 // Mock the SandboxManager before importing the plugin
 const mockInitialize = mock(() => Promise.resolve())
@@ -17,6 +18,8 @@ mock.module("@anthropic-ai/sandbox-runtime", () => ({
 
 import * as pluginModule from "../src/index"
 import { SandboxPlugin, server } from "../src/index"
+
+const sanitizedPersistenceWarning = "Failed to restore original command in tool history"
 
 const makeCtx = (
   dir = "/tmp/project",
@@ -38,6 +41,8 @@ describe("SandboxPlugin", () => {
     mockCleanupAfterCommand.mockClear()
     delete process.env.OPENCODE_DISABLE_SANDBOX
     delete process.env.OPENCODE_SANDBOX_CONFIG
+    delete process.env.OPENCODE_SERVER_PASSWORD
+    delete process.env.OPENCODE_SERVER_USERNAME
   })
 
   test("exports the server plugin target", () => {
@@ -359,10 +364,12 @@ describe("SandboxPlugin", () => {
     if (process.platform === "win32") return
 
     const update = mock(() => Promise.resolve())
+    const patch = mock(() => Promise.resolve({ data: undefined, error: undefined }))
     const hooks = await SandboxPlugin(
       makeCtx("/tmp/project", "/tmp/project", {
         app: { log: mock(() => Promise.resolve()) },
         part: { update },
+        _client: { patch },
       }),
     )
 
@@ -393,7 +400,519 @@ describe("SandboxPlugin", () => {
       partID: "p1",
       part,
     })
+    expect(patch).not.toHaveBeenCalled()
     expect(mockCleanupAfterCommand).not.toHaveBeenCalled()
+  })
+
+  test("logs a sanitized warning for a public client error result", async () => {
+    if (process.platform === "win32") return
+
+    const log = mock(() => Promise.resolve())
+    const update = mock(() =>
+      Promise.resolve({
+        data: undefined,
+        error: { message: "private transport diagnostic", credential: "fixture-credential" },
+      }),
+    )
+    const patch = mock(() => Promise.resolve({ data: undefined, error: undefined }))
+    const hooks = await SandboxPlugin(
+      makeCtx("/tmp/project", "/tmp/project", {
+        app: { log },
+        part: { update },
+        _client: { patch },
+      }),
+    )
+    const beforeOutput = { args: { command: "git status" } }
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      beforeOutput,
+    )
+    log.mockClear()
+
+    await hooks.event?.({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: "tool",
+            tool: "bash",
+            callID: "c1",
+            state: { status: "running", input: { command: beforeOutput.args.command } },
+          },
+        },
+      } as any,
+    })
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(patch).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenCalledWith({
+      body: {
+        service: "opencode-sandbox",
+        level: "warn",
+        message: sanitizedPersistenceWarning,
+      },
+    })
+    const logged = JSON.stringify(log.mock.calls)
+    expect(logged.includes("private transport diagnostic")).toBe(false)
+    expect(logged.includes("fixture-credential")).toBe(false)
+  })
+
+  test("logs a sanitized warning for a thrown public client error", async () => {
+    if (process.platform === "win32") return
+
+    const log = mock(() => Promise.resolve())
+    const update = mock(() =>
+      Promise.reject(
+        new Error("public transport failed for https://unsafe.example/?token=fixture-secret"),
+      ),
+    )
+    const patch = mock(() => Promise.resolve({ data: undefined, error: undefined }))
+    const hooks = await SandboxPlugin(
+      makeCtx("/tmp/project", "/tmp/project", {
+        app: { log },
+        part: { update },
+        _client: { patch },
+      }),
+    )
+    const beforeOutput = { args: { command: "git status" } }
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      beforeOutput,
+    )
+    log.mockClear()
+
+    await hooks.event?.({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: "tool",
+            tool: "bash",
+            callID: "c1",
+            state: { status: "running", input: { command: beforeOutput.args.command } },
+          },
+        },
+      } as any,
+    })
+
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(patch).not.toHaveBeenCalled()
+    expect(log).toHaveBeenCalledWith({
+      body: {
+        service: "opencode-sandbox",
+        level: "warn",
+        message: sanitizedPersistenceWarning,
+      },
+    })
+    const logged = JSON.stringify(log.mock.calls)
+    expect(logged.includes("https://unsafe.example/")).toBe(false)
+    expect(logged.includes("fixture-secret")).toBe(false)
+  })
+
+  test("uses the legacy client transport before the direct fetch fallback", async () => {
+    if (process.platform === "win32") return
+
+    const originalFetch = globalThis.fetch
+    const fetchMock = mock(() => Promise.reject(new Error("global fetch must not be called")))
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      const directory = "/tmp/project with space"
+      const requests: Array<{
+        method: string
+        url: string
+        contentType: string | null
+        directoryHeader: string | null
+        body: string
+      }> = []
+      const legacyFetch = mock(async (request: Request) => {
+        requests.push({
+          method: request.method,
+          url: request.url,
+          contentType: request.headers.get("content-type"),
+          directoryHeader: request.headers.get("x-opencode-directory"),
+          body: await request.text(),
+        })
+        return new Response(null, { status: 204 })
+      })
+      const client = createOpencodeClient({
+        baseUrl: "http://localhost:4096",
+        directory,
+        fetch: legacyFetch as typeof fetch,
+      }) as any
+      client.app = { ...client.app, log: mock(() => Promise.resolve()) }
+      const hooks = await SandboxPlugin(makeCtx(directory, directory, client))
+      const beforeOutput = { args: { command: "git status" } }
+      await hooks["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "session/one", callID: "c1" },
+        beforeOutput,
+      )
+
+      const part = {
+        id: "part?one",
+        sessionID: "session/one",
+        messageID: "message one",
+        type: "tool",
+        tool: "bash",
+        callID: "c1",
+        state: { status: "running", input: { command: beforeOutput.args.command } },
+      }
+      await hooks.event?.({
+        event: { type: "message.part.updated", properties: { part } } as any,
+      })
+
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(legacyFetch).toHaveBeenCalledTimes(1)
+      const persisted = requests[0]
+      const url = new URL(persisted?.url ?? "http://localhost")
+      expect(url.pathname).toBe("/session/session%2Fone/message/message%20one/part/part%3Fone")
+      expect(url.searchParams.get("directory")).toBe(directory)
+      expect(persisted?.method).toBe("PATCH")
+      expect(persisted?.contentType).toBe("application/json")
+      expect(persisted?.directoryHeader).toBe(encodeURIComponent(directory))
+      expect(JSON.parse(persisted?.body ?? "{}")).toEqual(part)
+      expect(part.state.input.command).toBe("git status")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("logs a sanitized warning for a legacy client transport error result", async () => {
+    if (process.platform === "win32") return
+
+    const directory = "/tmp/project"
+    const log = mock(() => Promise.resolve())
+    const legacyFetch = mock(() =>
+      Promise.resolve(
+        new Response("private transport diagnostic fixture-credential", { status: 503 }),
+      ),
+    )
+    const client = createOpencodeClient({
+      baseUrl: "http://localhost:4096",
+      directory,
+      fetch: legacyFetch as typeof fetch,
+    }) as any
+    client.app = { ...client.app, log }
+    const hooks = await SandboxPlugin(makeCtx(directory, directory, client))
+    const beforeOutput = { args: { command: "git status" } }
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      beforeOutput,
+    )
+    log.mockClear()
+
+    await hooks.event?.({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: "tool",
+            tool: "bash",
+            callID: "c1",
+            state: { status: "running", input: { command: beforeOutput.args.command } },
+          },
+        },
+      } as any,
+    })
+
+    expect(log).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenCalledWith({
+      body: {
+        service: "opencode-sandbox",
+        level: "warn",
+        message: sanitizedPersistenceWarning,
+      },
+    })
+    const logged = JSON.stringify(log.mock.calls)
+    expect(logged.includes("private transport diagnostic")).toBe(false)
+    expect(logged.includes("fixture-credential")).toBe(false)
+  })
+
+  test("logs a sanitized warning for a thrown legacy client transport error", async () => {
+    if (process.platform === "win32") return
+
+    const directory = "/tmp/project"
+    const log = mock(() => Promise.resolve())
+    const legacyFetch = mock(() =>
+      Promise.reject(
+        new Error("legacy transport failed for https://unsafe.example/?token=fixture-secret"),
+      ),
+    )
+    const client = createOpencodeClient({
+      baseUrl: "http://localhost:4096",
+      directory,
+      fetch: legacyFetch as typeof fetch,
+    }) as any
+    client.app = { ...client.app, log }
+    const hooks = await SandboxPlugin(makeCtx(directory, directory, client))
+    const beforeOutput = { args: { command: "git status" } }
+    await hooks["tool.execute.before"]?.(
+      { tool: "bash", sessionID: "s1", callID: "c1" },
+      beforeOutput,
+    )
+    log.mockClear()
+
+    await hooks.event?.({
+      event: {
+        type: "message.part.updated",
+        properties: {
+          part: {
+            id: "p1",
+            sessionID: "s1",
+            messageID: "m1",
+            type: "tool",
+            tool: "bash",
+            callID: "c1",
+            state: { status: "running", input: { command: beforeOutput.args.command } },
+          },
+        },
+      } as any,
+    })
+
+    expect(log).toHaveBeenCalledWith({
+      body: {
+        service: "opencode-sandbox",
+        level: "warn",
+        message: sanitizedPersistenceWarning,
+      },
+    })
+    const logged = JSON.stringify(log.mock.calls)
+    expect(logged.includes("https://unsafe.example/")).toBe(false)
+    expect(logged.includes("fixture-secret")).toBe(false)
+  })
+
+  test("falls back to the server API when the client has no SDK part transport", async () => {
+    if (process.platform === "win32") return
+
+    const originalFetch = globalThis.fetch
+    const fetchMock = mock(() => Promise.resolve(new Response(null, { status: 204 })))
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      const directory = "/tmp/project with space"
+      const hooks = await SandboxPlugin(makeCtx(directory))
+      const beforeOutput = { args: { command: "git status" } }
+      await hooks["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "session/one", callID: "c1" },
+        beforeOutput,
+      )
+
+      const part = {
+        id: "part?one",
+        sessionID: "session/one",
+        messageID: "message one",
+        type: "tool",
+        tool: "bash",
+        callID: "c1",
+        state: { status: "running", input: { command: beforeOutput.args.command } },
+      }
+      await hooks.event?.({
+        event: { type: "message.part.updated", properties: { part } } as any,
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [request, init] = fetchMock.mock.calls[0] ?? []
+      const url = new URL(String(request))
+      expect(url.pathname).toBe("/session/session%2Fone/message/message%20one/part/part%3Fone")
+      expect(url.searchParams.get("directory")).toBe(directory)
+      expect(init?.method).toBe("PATCH")
+      expect(new Headers(init?.headers).get("content-type")).toBe("application/json")
+      const patchedPart = JSON.parse(String(init?.body))
+      expect(patchedPart.state.input.command === "git status").toBe(true)
+      expect(part.state.input.command).toBe("git status")
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("logs a sanitized warning when the server API rejects the part update", async () => {
+    if (process.platform === "win32") return
+
+    const originalFetch = globalThis.fetch
+    const fetchMock = mock(() =>
+      Promise.resolve(new Response("internal diagnostic details", { status: 503 })),
+    )
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      process.env.OPENCODE_SERVER_PASSWORD = "fixture-password"
+      process.env.OPENCODE_SERVER_USERNAME = "fixture-user"
+      const log = mock(() => Promise.resolve())
+      const hooks = await SandboxPlugin(makeCtx("/tmp/project", "/tmp/project", { app: { log } }))
+      const beforeOutput = { args: { command: "git status" } }
+      await hooks["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "s1", callID: "c1" },
+        beforeOutput,
+      )
+
+      await hooks.event?.({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "p1",
+              sessionID: "s1",
+              messageID: "m1",
+              type: "tool",
+              tool: "bash",
+              callID: "c1",
+              state: { status: "running", input: { command: beforeOutput.args.command } },
+            },
+          },
+        } as any,
+      })
+
+      expect(log).toHaveBeenCalledWith({
+        body: {
+          service: "opencode-sandbox",
+          level: "warn",
+          message: sanitizedPersistenceWarning,
+        },
+      })
+      const logged = JSON.stringify(log.mock.calls)
+      expect(logged.includes("internal diagnostic details")).toBe(false)
+      expect(logged.includes("fixture-password")).toBe(false)
+      expect(logged.includes("fixture-user")).toBe(false)
+    } finally {
+      delete process.env.OPENCODE_SERVER_PASSWORD
+      delete process.env.OPENCODE_SERVER_USERNAME
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("logs a sanitized warning when the direct server fetch throws", async () => {
+    if (process.platform === "win32") return
+
+    const originalFetch = globalThis.fetch
+    const fetchMock = mock(() =>
+      Promise.reject(
+        new Error("direct transport failed for https://unsafe.example/?token=fixture-secret"),
+      ),
+    )
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      const log = mock(() => Promise.resolve())
+      const hooks = await SandboxPlugin(makeCtx("/tmp/project", "/tmp/project", { app: { log } }))
+      const beforeOutput = { args: { command: "git status" } }
+      await hooks["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "s1", callID: "c1" },
+        beforeOutput,
+      )
+      log.mockClear()
+
+      await hooks.event?.({
+        event: {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "p1",
+              sessionID: "s1",
+              messageID: "m1",
+              type: "tool",
+              tool: "bash",
+              callID: "c1",
+              state: { status: "running", input: { command: beforeOutput.args.command } },
+            },
+          },
+        } as any,
+      })
+
+      expect(log).toHaveBeenCalledWith({
+        body: {
+          service: "opencode-sandbox",
+          level: "warn",
+          message: sanitizedPersistenceWarning,
+        },
+      })
+      const logged = JSON.stringify(log.mock.calls)
+      expect(logged.includes("https://unsafe.example/")).toBe(false)
+      expect(logged.includes("fixture-secret")).toBe(false)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("matches OpenCode Basic auth semantics for empty credentials", async () => {
+    if (process.platform === "win32") return
+
+    const originalFetch = globalThis.fetch
+    const fetchMock = mock(() => Promise.resolve(new Response(null, { status: 204 })))
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      const cases = [
+        { password: undefined, username: undefined, expectedUsername: undefined },
+        { password: "", username: "fixture-user", expectedUsername: undefined },
+        { password: "fixture-password", username: undefined, expectedUsername: "opencode" },
+        { password: "fixture-password", username: "", expectedUsername: "" },
+        {
+          password: "fixture-password",
+          username: "fixture-user",
+          expectedUsername: "fixture-user",
+        },
+      ]
+
+      for (const { password, username, expectedUsername } of cases) {
+        fetchMock.mockClear()
+        if (password === undefined) delete process.env.OPENCODE_SERVER_PASSWORD
+        else process.env.OPENCODE_SERVER_PASSWORD = password
+        if (username === undefined) delete process.env.OPENCODE_SERVER_USERNAME
+        else process.env.OPENCODE_SERVER_USERNAME = username
+
+        const hooks = await SandboxPlugin(makeCtx())
+        const beforeOutput = { args: { command: "git status" } }
+        await hooks["tool.execute.before"]?.(
+          { tool: "bash", sessionID: "s1", callID: "c1" },
+          beforeOutput,
+        )
+        await hooks.event?.({
+          event: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "p1",
+                sessionID: "s1",
+                messageID: "m1",
+                type: "tool",
+                tool: "bash",
+                callID: "c1",
+                state: { status: "running", input: { command: beforeOutput.args.command } },
+              },
+            },
+          } as any,
+        })
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+        const [, init] = fetchMock.mock.calls[0] ?? []
+        const authorization = new Headers(init?.headers).get("authorization")
+        if (expectedUsername === undefined) {
+          expect(authorization).toBeNull()
+          continue
+        }
+
+        const decoded = Buffer.from(
+          authorization?.slice("Basic ".length) ?? "",
+          "base64",
+        ).toString()
+        expect(authorization?.startsWith("Basic ")).toBe(true)
+        expect(decoded === `${expectedUsername}:${password}`).toBe(true)
+      }
+    } finally {
+      delete process.env.OPENCODE_SERVER_PASSWORD
+      delete process.env.OPENCODE_SERVER_USERNAME
+      globalThis.fetch = originalFetch
+    }
   })
 
   test("restores the persisted command after tool.execute.after runs", async () => {
@@ -430,56 +949,130 @@ describe("SandboxPlugin", () => {
     expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
   })
 
-  test("restores a completed part persisted after its running update", async () => {
+  test("cleans a completed command before its restored input finishes persisting", async () => {
     if (process.platform === "win32") return
 
-    let persistedCommand: unknown
-    const update = mock(({ part }: { part: { state?: { input?: { command?: unknown } } } }) => {
-      persistedCommand = part.state?.input?.command
-      return Promise.resolve()
+    let resolvePersistence!: () => void
+    const persistence = new Promise<void>((resolve) => {
+      resolvePersistence = resolve
     })
+    const update = mock(() => persistence)
     const hooks = await SandboxPlugin(
       makeCtx("/tmp/project", "/tmp/project", {
         app: { log: mock(() => Promise.resolve()) },
         part: { update },
       }),
     )
-
     const input = { tool: "bash", sessionID: "s1", callID: "c1" }
     const output = { args: { command: "git status" } }
     await hooks["tool.execute.before"]?.(input, output)
-    const wrappedCommand = output.args.command
 
-    const dispatchPersistedPart = async (status: "running" | "completed") => {
-      const part = {
-        id: "p1",
-        sessionID: "s1",
-        messageID: "m1",
-        type: "tool",
-        tool: "bash",
-        callID: "c1",
-        state: { status, input: { command: wrappedCommand } },
-      }
-      persistedCommand = part.state.input.command
-      await hooks.event?.({
-        event: { type: "message.part.updated", properties: { part } } as any,
-      })
+    const part = {
+      id: "p1",
+      sessionID: "s1",
+      messageID: "m1",
+      type: "tool",
+      tool: "bash",
+      callID: "c1",
+      state: { status: "completed", input: { command: output.args.command } },
     }
+    const terminalEvent = hooks.event?.({
+      event: { type: "message.part.updated", properties: { part } } as any,
+    })
 
-    await dispatchPersistedPart("running")
-    await hooks["tool.execute.after"]?.({ ...input, args: output.args }, {})
-    await dispatchPersistedPart("completed")
-
-    expect(persistedCommand).toBe("git status")
-    expect(update).toHaveBeenCalledTimes(2)
+    try {
+      expect(part.state.input.command).toBe("git status")
+      expect(update).toHaveBeenCalledTimes(1)
+      expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+    } finally {
+      resolvePersistence()
+      await terminalEvent
+    }
+    await hooks.event?.({
+      event: { type: "message.part.updated", properties: { part: structuredClone(part) } } as any,
+    })
     expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
   })
 
-  test("does not re-persist an already restored tool part", async () => {
+  test("restores legacy client running and completed snapshots without persistence loops", async () => {
     if (process.platform === "win32") return
 
-    const update = mock(() => Promise.resolve())
-    const hooks = await SandboxPlugin(
+    const originalFetch = globalThis.fetch
+    const persisted = new Map<string, any>()
+    const fetchMock = mock(() => Promise.reject(new Error("global fetch must not be called")))
+    let hooks: any
+    const legacyFetch = mock(async (request: Request) => {
+      const part = JSON.parse(await request.text())
+      persisted.set(part.callID, structuredClone(part))
+      await hooks.event?.({
+        event: {
+          type: "message.part.updated",
+          properties: { part: structuredClone(part) },
+        } as any,
+      })
+      return new Response(null, { status: 204 })
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      const client = createOpencodeClient({
+        baseUrl: "http://localhost:4096",
+        directory: "/tmp/project",
+        fetch: legacyFetch as typeof fetch,
+      }) as any
+      client.app = { ...client.app, log: mock(() => Promise.resolve()) }
+      hooks = await SandboxPlugin(makeCtx("/tmp/project", "/tmp/project", client))
+      const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+      const output = { args: { command: "git status" } }
+      await hooks["tool.execute.before"]?.(input, output)
+      const wrappedCommand = output.args.command
+
+      const dispatchPersistedPart = async (status: "running" | "completed") => {
+        const part = {
+          id: "p1",
+          sessionID: "s1",
+          messageID: "m1",
+          type: "tool",
+          tool: "bash",
+          callID: "c1",
+          state: { status, input: { command: wrappedCommand } },
+        }
+        persisted.set(part.callID, structuredClone(part))
+        await hooks.event?.({
+          event: { type: "message.part.updated", properties: { part } } as any,
+        })
+      }
+
+      await dispatchPersistedPart("running")
+      expect(persisted.get("c1")?.state.status).toBe("running")
+      expect(persisted.get("c1")?.state.input.command === "git status").toBe(true)
+
+      await hooks["tool.execute.after"]?.({ ...input, args: output.args }, {})
+      await dispatchPersistedPart("completed")
+
+      expect(legacyFetch).toHaveBeenCalledTimes(2)
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(persisted.get("c1")?.state.status).toBe("completed")
+      expect(persisted.get("c1")?.state.input.command === "git status").toBe(true)
+      expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
+  test("does not re-persist an equal part update echoed by the client", async () => {
+    if (process.platform === "win32") return
+
+    let hooks: any
+    const update = mock(async ({ part }: { part: any }) => {
+      await hooks.event?.({
+        event: {
+          type: "message.part.updated",
+          properties: { part: structuredClone(part) },
+        } as any,
+      })
+    })
+    hooks = await SandboxPlugin(
       makeCtx("/tmp/project", "/tmp/project", {
         app: { log: mock(() => Promise.resolve()) },
         part: { update },
@@ -503,9 +1096,97 @@ describe("SandboxPlugin", () => {
     }
 
     await hooks.event?.({ event: { type: "message.part.updated", properties: { part } } as any })
-    await hooks.event?.({ event: { type: "message.part.updated", properties: { part } } as any })
 
     expect(update).toHaveBeenCalledTimes(1)
     expect(part.state.input.command).toBe("echo hello")
+  })
+
+  test("isolates concurrent legacy fallback updates and cleans terminal calls exactly once", async () => {
+    if (process.platform === "win32") return
+
+    const originalFetch = globalThis.fetch
+    const persisted = new Map<string, any>()
+    const fetchMock = mock((_request: RequestInfo | URL, init?: RequestInit) => {
+      const part = JSON.parse(String(init?.body))
+      persisted.set(part.callID, structuredClone(part))
+      return Promise.resolve(new Response(null, { status: 204 }))
+    })
+    globalThis.fetch = fetchMock as typeof fetch
+
+    try {
+      const hooks = await SandboxPlugin(makeCtx())
+      const commands = new Map([
+        ["c1", "echo first"],
+        ["c2", "echo second"],
+      ])
+      const wrapped = new Map<string, string>()
+
+      for (const [callID, command] of commands) {
+        const output = { args: { command } }
+        await hooks["tool.execute.before"]?.({ tool: "bash", sessionID: "s1", callID }, output)
+        wrapped.set(callID, output.args.command)
+      }
+
+      const dispatchPersistedPart = async (
+        callID: string,
+        status: "running" | "completed" | "error",
+      ) => {
+        const part = {
+          id: `p-${callID}`,
+          sessionID: "s1",
+          messageID: `m-${callID}`,
+          type: "tool",
+          tool: "bash",
+          callID,
+          state: { status, input: { command: wrapped.get(callID) } },
+        }
+        persisted.set(callID, structuredClone(part))
+        await hooks.event?.({
+          event: { type: "message.part.updated", properties: { part } } as any,
+        })
+        return part
+      }
+
+      await dispatchPersistedPart("c1", "running")
+      await dispatchPersistedPart("c2", "running")
+      expect(persisted.get("c1")?.state.input.command === commands.get("c1")).toBe(true)
+      expect(persisted.get("c2")?.state.input.command === commands.get("c2")).toBe(true)
+
+      await hooks["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "s1", callID: "c1", args: { command: wrapped.get("c1") } },
+        {},
+      )
+      const errored = await dispatchPersistedPart("c2", "error")
+      await hooks.event?.({
+        event: {
+          type: "message.part.updated",
+          properties: { part: structuredClone(errored) },
+        } as any,
+      })
+      await hooks["tool.execute.after"]?.(
+        { tool: "bash", sessionID: "s1", callID: "c2", args: { command: wrapped.get("c2") } },
+        {},
+      )
+
+      const completed = await dispatchPersistedPart("c1", "completed")
+      await hooks.event?.({
+        event: {
+          type: "message.part.updated",
+          properties: { part: structuredClone(completed) },
+        } as any,
+      })
+      await hooks.event?.({
+        event: { type: "session.idle", properties: { sessionID: "s1" } } as any,
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(4)
+      expect(persisted.get("c1")?.state.status).toBe("completed")
+      expect(persisted.get("c2")?.state.status).toBe("error")
+      expect(persisted.get("c1")?.state.input.command === commands.get("c1")).toBe(true)
+      expect(persisted.get("c2")?.state.input.command === commands.get("c2")).toBe(true)
+      expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(2)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
   })
 })

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -430,7 +430,52 @@ describe("SandboxPlugin", () => {
     expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
   })
 
-  test("restores persisted tool part only once per part", async () => {
+  test("restores a completed part persisted after its running update", async () => {
+    if (process.platform === "win32") return
+
+    let persistedCommand: unknown
+    const update = mock(({ part }: { part: { state?: { input?: { command?: unknown } } } }) => {
+      persistedCommand = part.state?.input?.command
+      return Promise.resolve()
+    })
+    const hooks = await SandboxPlugin(
+      makeCtx("/tmp/project", "/tmp/project", {
+        app: { log: mock(() => Promise.resolve()) },
+        part: { update },
+      }),
+    )
+
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: "git status" } }
+    await hooks["tool.execute.before"]?.(input, output)
+    const wrappedCommand = output.args.command
+
+    const dispatchPersistedPart = async (status: "running" | "completed") => {
+      const part = {
+        id: "p1",
+        sessionID: "s1",
+        messageID: "m1",
+        type: "tool",
+        tool: "bash",
+        callID: "c1",
+        state: { status, input: { command: wrappedCommand } },
+      }
+      persistedCommand = part.state.input.command
+      await hooks.event?.({
+        event: { type: "message.part.updated", properties: { part } } as any,
+      })
+    }
+
+    await dispatchPersistedPart("running")
+    await hooks["tool.execute.after"]?.({ ...input, args: output.args }, {})
+    await dispatchPersistedPart("completed")
+
+    expect(persistedCommand).toBe("git status")
+    expect(update).toHaveBeenCalledTimes(2)
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
+  })
+
+  test("does not re-persist an already restored tool part", async () => {
     if (process.platform === "win32") return
 
     const update = mock(() => Promise.resolve())
@@ -458,7 +503,6 @@ describe("SandboxPlugin", () => {
     }
 
     await hooks.event?.({ event: { type: "message.part.updated", properties: { part } } as any })
-    part.state.input.command = beforeOutput.args.command
     await hooks.event?.({ event: { type: "message.part.updated", properties: { part } } as any })
 
     expect(update).toHaveBeenCalledTimes(1)

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -15,7 +15,8 @@ mock.module("@anthropic-ai/sandbox-runtime", () => ({
   },
 }))
 
-import { isSandboxWrappedCommand, SandboxPlugin, server } from "../src/index"
+import * as pluginModule from "../src/index"
+import { SandboxPlugin, server } from "../src/index"
 
 const makeCtx = (
   dir = "/tmp/project",
@@ -41,6 +42,17 @@ describe("SandboxPlugin", () => {
 
   test("exports the server plugin target", () => {
     expect(server).toBe(SandboxPlugin)
+  })
+
+  test("exposes no helper functions for legacy plugin discovery", async () => {
+    const plugins = [
+      ...new Set(Object.values(pluginModule).filter((value) => typeof value === "function")),
+    ]
+    expect(plugins).toEqual([SandboxPlugin])
+
+    for (const plugin of plugins) {
+      await (plugin as typeof SandboxPlugin)(makeCtx())
+    }
   })
 
   test("initializes sandbox only when the first bash command runs", async () => {
@@ -95,18 +107,30 @@ describe("SandboxPlugin", () => {
     expect(output.args.command).toBe(alreadyWrapped)
   })
 
-  test("detects sandbox-runtime wrappers without matching ordinary commands", () => {
-    expect(
-      isSandboxWrappedCommand(
-        "bwrap --new-session --die-with-parent --setenv SANDBOX_RUNTIME 1 -- /usr/bin/bash -c 'echo hello'",
-      ),
-    ).toBe(true)
-    expect(
-      isSandboxWrappedCommand(
-        "env SANDBOX_RUNTIME=1 TMPDIR=/tmp/claude /usr/bin/sandbox-exec -p '(version 1)' /bin/bash -c 'echo hello'",
-      ),
-    ).toBe(true)
-    expect(isSandboxWrappedCommand("echo SANDBOX_RUNTIME=1 bwrap")).toBe(false)
+  test("detects sandbox-runtime wrappers without matching ordinary commands", async () => {
+    if (process.platform === "win32") return
+
+    const hooks = await SandboxPlugin(makeCtx())
+    const linuxWrapper =
+      "bwrap --new-session --die-with-parent --setenv SANDBOX_RUNTIME 1 -- /usr/bin/bash -c 'echo hello'"
+    const macosWrapper =
+      "env SANDBOX_RUNTIME=1 TMPDIR=/tmp/claude /usr/bin/sandbox-exec -p '(version 1)' /bin/bash -c 'echo hello'"
+    const ordinaryCommand = "echo SANDBOX_RUNTIME=1 bwrap"
+    const outputs = [linuxWrapper, macosWrapper, ordinaryCommand].map((command) => ({
+      args: { command },
+    }))
+
+    for (const [index, output] of outputs.entries()) {
+      await hooks["tool.execute.before"]?.(
+        { tool: "bash", sessionID: "s1", callID: `c${index + 1}` },
+        output,
+      )
+    }
+
+    expect(outputs[0]?.args.command).toBe(linuxWrapper)
+    expect(outputs[1]?.args.command).toBe(macosWrapper)
+    expect(outputs[2]?.args.command).toBe(`srt-wrapped: ${ordinaryCommand}`)
+    expect(mockWrapWithSandbox).toHaveBeenCalledTimes(1)
   })
 
   test("does not wrap non-bash tools", async () => {
@@ -370,6 +394,40 @@ describe("SandboxPlugin", () => {
       part,
     })
     expect(mockCleanupAfterCommand).not.toHaveBeenCalled()
+  })
+
+  test("restores the persisted command after tool.execute.after runs", async () => {
+    if (process.platform === "win32") return
+
+    const update = mock(() => Promise.resolve())
+    const hooks = await SandboxPlugin(
+      makeCtx("/tmp/project", "/tmp/project", {
+        app: { log: mock(() => Promise.resolve()) },
+        part: { update },
+      }),
+    )
+
+    const input = { tool: "bash", sessionID: "s1", callID: "c1" }
+    const output = { args: { command: "git status" } }
+    await hooks["tool.execute.before"]?.(input, output)
+    await hooks["tool.execute.after"]?.({ ...input, args: output.args }, {})
+
+    const part = {
+      id: "p1",
+      sessionID: "s1",
+      messageID: "m1",
+      type: "tool",
+      tool: "bash",
+      callID: "c1",
+      state: { status: "completed", input: { command: "srt-wrapped: git status" } },
+    }
+    await hooks.event?.({
+      event: { type: "message.part.updated", properties: { part } } as any,
+    })
+
+    expect(part.state.input.command).toBe("git status")
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(mockCleanupAfterCommand).toHaveBeenCalledTimes(1)
   })
 
   test("restores persisted tool part only once per part", async () => {


### PR DESCRIPTION
## Summary

Fixes command-history persistence compatibility with OpenCode 1.18.26. Several lifecycle and transport behaviors combined to leave the generated sandbox command in persisted tool history instead of the original command.

## Compatibility causes

- `tool.execute.after` evicted per-call state before the terminal `message.part.updated` snapshot arrived.
- Running and completed snapshots can reuse the same part ID, so each wrapper-bearing snapshot must be repaired rather than deduplicated by ID.
- The OpenCode 1.18.26 legacy `PluginInput` client does not expose public `part.update`.
- An in-process `serverUrl` may not have a reachable HTTP listener, so persistence uses the configured internal `_client.patch` transport before direct fetch fallback.
- Terminal cleanup must happen before awaiting persistence so sandbox resources are released promptly while command state remains available for the update.

## Changes

- Preserve original command state through terminal part persistence while keeping cleanup idempotent.
- Restore each wrapper-bearing running, completed, or interrupted snapshot and avoid persistence loops for already-restored input.
- Support public part update, legacy internal client transport, and direct server fallback in that order.
- Sanitize persistence warnings so transport details are not logged.
- Add regressions for lifecycle ordering, repeated part IDs, transport selection, failures, authentication semantics, and concurrent calls.

## Verification

- [x] Plugin tests: 33 passing
- [x] Full test suite: 53 passing
- [x] Typecheck
- [x] Lint
- [x] Biome check
- [x] Build
- [x] Lifecycle stress: 330 passing executions
- [x] Fresh OpenCode 1.18.26 E2E: command execution succeeded; the persisted command exactly matched the original with zero wrapper markers or warnings